### PR TITLE
app:fido2: Fix error logging and handling in FIDO2 flows

### DIFF
--- a/app/fido2sample/fido2sample/fido2/Authentication.swift
+++ b/app/fido2sample/fido2sample/fido2/Authentication.swift
@@ -52,7 +52,7 @@ class Authentication: NSObject {
             ## Retrieve FIDO2 response ##
         } catch let error {
             completion(error)
-            Logger.log(string: "Registration Error:\n" + error.localizedDescription)
+            Logger.log(string: "Authentication Error:\n" + error.localizedDescription)
         }
     }
 }

--- a/app/fido2sample/fido2sample/fido2/Registration.swift
+++ b/app/fido2sample/fido2sample/fido2/Registration.swift
@@ -56,7 +56,7 @@ class Registration: NSObject {
         do {
             // Create Registration request providing the required credentials.
             /* 1 */
-             ## Create Fido2 request with json String ##
+            ## Create Fido2 request with json String ##
             
             // Setup an instance of TGFFido2RespondArgsBuilder with registration request
             // Initialize all necessary UI delegates required by FIDO2 SDK.
@@ -64,12 +64,16 @@ class Registration: NSObject {
             // Required callbacks are essential to ensure a proper UX behaviour.
             // As a means of convenience, the FIDO2 UI SDK provides a ClientConformer class which conforms to all necessary delegates of FIDO2 SDK
             /* 2 */
-             ## Setup TGFFido2RespondArgsBuilder with UI delegates ##
+            ## Setup TGFFido2RespondArgsBuilder with UI delegates ##
             
             // Retrieve the FIDO2 Registration response.
             // Handle on error or response
             /* 3 */
-             ## Retrieve FIDO2 response ##
+            ## Retrieve FIDO2 response ##
             
+        } catch let error {
+            completion(error)
+            Logger.log(string: "Registration Error:\n" + error.localizedDescription)
+        }
     }
 }


### PR DESCRIPTION
Corrected error log messages in Authentication.swift to reference 'Authentication Error' instead of 'Registration Error'. Added missing error handling and logging in Registration.swift to ensure errors are properly reported during registration.